### PR TITLE
Improve UI of AddToAlbum popup on photo page

### DIFF
--- a/frontend/src/Components/Shared/AddToAlbum.tsx
+++ b/frontend/src/Components/Shared/AddToAlbum.tsx
@@ -6,7 +6,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
-import { ListItem, ListItemText, Checkbox } from "@material-ui/core";
+import { ListItem, ListItemText, Checkbox, Typography } from "@material-ui/core";
 import { AlbumT } from "../../Interfaces";
 import CreateAlbum from "../AlbumPage/CreateAlbum";
 import { createAlbum } from "../../API";
@@ -72,12 +72,13 @@ export default function AddToAlbum(props: { cb: (arg0: string[]) => any; setOpen
                     {albums.map((album: any) => (
                         <Element album={album} add={add} remove={remove} key={album.id} />
                     ))}
+                    {albums.length === 0 && <Typography variant="subtitle1">There are no albums</Typography>}
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={() => setOpenCreateAlbum(true)} color="primary">
                         Create new album
                     </Button>
-                    <Button onClick={handleClose(true)} color="primary" autoFocus>
+                    <Button onClick={handleClose(true)} color="primary" disabled={albums.length === 0} autoFocus>
                         Add
                     </Button>
                 </DialogActions>


### PR DESCRIPTION
Hello,
I am very excited about how great this project looks. When I was playing around with it, I thought that the UI of the "add to album" popup on the photo page could be tweaked slightly. Specifically, this small change disables the "Add" button when no albums exist. Additionally, it displays text that states "There are no albums" if none exist.

Screenshot:
<img width="248" alt="Screen Shot 2021-02-08 at 1 39 30 AM" src="https://user-images.githubusercontent.com/19192015/107184411-80bc9280-69ae-11eb-8850-cee09c668d7e.png">

I wasn't sure if this should be merged into the main or UI-improvements branch.

I am still learning to work on collaborative Git projects, so I decided to start with a small feature.

Thanks for your work,
Sawyer


