### PR TITLE
Improve UI of add-to-album popup on photo page

### DIFF
--- a/frontend/src/Components/Shared/AddToAlbum.tsx
+++ b/frontend/src/Components/Shared/AddToAlbum.tsx
@@ -6,7 +6,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
-import { ListItem, ListItemText, Checkbox } from "@material-ui/core";
+import { ListItem, ListItemText, Checkbox, Typography } from "@material-ui/core";
 import { AlbumT } from "../../Interfaces";
 import CreateAlbum from "../AlbumPage/CreateAlbum";
 import { createAlbum } from "../../API";
@@ -72,6 +72,7 @@ export default function AddToAlbum(props: { cb: (arg0: string[]) => any; setOpen
                     {albums.map((album: any) => (
                         <Element album={album} add={add} remove={remove} key={album.id} />
                     ))}
+                    {albums.length === 0 && <Typography variant="subtitle1">There are no albums</Typography>}
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={() => setOpenCreateAlbum(true)} color="primary">


### PR DESCRIPTION
Hello,
Here's the updated pull request.

This change makes the UI of the add-to-album popup on the photo page more descriptive by displaying text that states "There are no albums" if none exist.